### PR TITLE
fix autoinstall.sh handle empty SSH key title and suppress passphrase…

### DIFF
--- a/.termux/autoinstall.sh
+++ b/.termux/autoinstall.sh
@@ -33,7 +33,6 @@ read -rp "${GREEN}Enter your Git email${ENDCOLOR}: " email
 
 # Prompt the user for the name associated with the SSH key
 read -rp "${GREEN}Enter a name you would like associated with the SSH key for easy recognition on GitHub (Title) [Press Enter for default: id_ed25519]${ENDCOLOR}: " key_title
-# CORREÇÃO: Garante um nome padrão se a variável estiver vazia
 key_title=${key_title:-id_ed25519}
 
 # Prompt the user to choose between global and system-wide configuration
@@ -42,7 +41,6 @@ read -rp "${GREEN}Would you like to set your Git configuration system-wide? (Yes
 # Set Up SSH Key
 if [ ! -f ~/.ssh/"$key_title" ]; then
   # Generate an Ed25519 SSH key pair
-  # CORREÇÃO: Adicionado -N "" para não pedir senha e travar o script
   ssh-keygen -f ~/.ssh/"$key_title" -C "$email" -N ""
   # Check if an SSH key pair already exists
   eval "$(ssh-agent -s)"

--- a/.termux/autoinstall.sh
+++ b/.termux/autoinstall.sh
@@ -32,7 +32,9 @@ read -rp "${GREEN}Enter your Git username${ENDCOLOR}: " username
 read -rp "${GREEN}Enter your Git email${ENDCOLOR}: " email
 
 # Prompt the user for the name associated with the SSH key
-read -rp "${GREEN}Enter a name you would like associated with the SSH key for easy recognition on GitHub (Title)${ENDCOLOR}: " key_title
+read -rp "${GREEN}Enter a name you would like associated with the SSH key for easy recognition on GitHub (Title) [Press Enter for default: id_ed25519]${ENDCOLOR}: " key_title
+# CORREÇÃO: Garante um nome padrão se a variável estiver vazia
+key_title=${key_title:-id_ed25519}
 
 # Prompt the user to choose between global and system-wide configuration
 read -rp "${GREEN}Would you like to set your Git configuration system-wide? (Yes/No)${ENDCOLOR}: " choice
@@ -40,12 +42,14 @@ read -rp "${GREEN}Would you like to set your Git configuration system-wide? (Yes
 # Set Up SSH Key
 if [ ! -f ~/.ssh/"$key_title" ]; then
   # Generate an Ed25519 SSH key pair
-  ssh-keygen -f ~/.ssh/"$key_title" -C "$email"
+  # CORREÇÃO: Adicionado -N "" para não pedir senha e travar o script
+  ssh-keygen -f ~/.ssh/"$key_title" -C "$email" -N ""
   # Check if an SSH key pair already exists
   eval "$(ssh-agent -s)"
   ssh-add ~/.ssh/"$key_title"
 else
   echo -e "${YELLOW}SSH key already exists. Skipping SSH key generation. Adding SSH key to SSH-agent${ENDCOLOR}."
+  eval "$(ssh-agent -s)"
   ssh-add ~/.ssh/"$key_title"
 fi
 


### PR DESCRIPTION
## 🛠️ Fix: SSH Key Generation Failure on Empty Input

### 📝 Description
This PR fixes a critical bug in the SSH setup flow. Previously, if a user pressed **Enter** without providing a title for the SSH key, the script would attempt to use an empty variable for the file path, leading to a collision with the `.ssh/` directory.

### ❌ The Problem
- The `$key_title` variable remained empty on null input.
- `ssh-keygen` attempted to save the key as `~/.ssh/`, which failed with the error: **"Is a directory"**.
- Subsequent commands (like `gh ssh-key add`) failed because they couldn't find the expected `.pub` file.

**Error logs:**
![Screenshot_2025-12-18-10-17-00-249_com termux-edit](https://github.com/user-attachments/assets/4cb8a4c3-3260-47cb-b220-fb98b3287278)

---

### ✅ The Solution
1. **Default Value Assignment:** Implemented shell parameter expansion `${key_title:-id_ed25519}` to ensure the script always has a valid filename, even if the user leaves the prompt blank.
2. **Non-Interactive Execution:** Added the `-N ""` flag to the `ssh-keygen` command. This prevents the script from hanging or failing while waiting for a passphrase, making the installation smoother.

**Success / Verification:**
![Screenshot_2025-12-18-10-19-26-427_com termux-edit](https://github.com/user-attachments/assets/b1df5b20-2615-475e-aa46-1813590fd54d)

---
*Generated by contributing to improve the automation robustness of this repository.*
